### PR TITLE
The first element of assays in SE might be a matrix when using DESeq2 method

### DIFF
--- a/R/functions_SE.R
+++ b/R/functions_SE.R
@@ -1093,6 +1093,10 @@ get_differential_transcript_abundance_deseq2_SE <- function(.data,
         }
   
 	my_contrasts = .contrasts
+    
+       if (!inherits(assays(.data)[[1]], 'matrix')){
+           assays(.data)[[1]] <- as.matrix(assays(.data)[[1]])
+       }
 
 	deseq2_object =
 		.data %>%


### PR DESCRIPTION
The related issue

```
> library(tidybulk)
========================================
tidybulk version 1.12.0
If you use TIDYBULK in published research, please cite:

Mangiola et al. tidybulk: an R tidy framework for modular
transcriptomic data analysis. Genome Biology 2021.

This message can be suppressed by:
  suppressPackageStartupMessages(library(tidybulk))
========================================
> library(SummarizedExperiment) %>% suppressPackageStartupMessages()
> assays(se_mini)[[1]] <- assays(se_mini)[[1]] %>% data.frame()
> se_mini %>% identify_abundant() %>% test_differential_abundance(.formula=~condition, method='DESeq2')
No group or design set. Assuming all samples belong to one group.
renaming the first element in assays to 'counts'
Error in DESeq2::DESeqDataSet(., design = .formula) :
  counts matrix should be numeric, currently it has mode: list
>
```

when convert it to matrix, it works

```
> assays(se_mini)[[1]] <- assays(se_mini)[[1]] %>% as.matrix()
> se_mini %>% identify_abundant() %>% test_differential_abundance(.formula=~condition, method='DESeq2')
No group or design set. Assuming all samples belong to one group.
renaming the first element in assays to 'counts'
converting counts to integer mode
estimating size factors
estimating dispersions
gene-wise dispersion estimates
mean-dispersion relationship
-- note: fitType='parametric', but the dispersion trend was not well captured by the
   function: y = a/x + b, and a local regression fit was automatically substituted.
   specify fitType='local' or 'mean' to avoid this message next time.
final dispersion estimates
fitting model and testing
tidybulk says: to access the raw results (fitted GLM) do `attr(..., "internals")$DESeq2`
class: SummarizedExperiment
dim: 527 5
metadata(0):
assays(1): count
rownames(527): ABCB4 ABCB9 ... ZNF324 ZNF442
rowData names(8): entrez .abundant ... pvalue padj
colnames(5): SRR1740034 SRR1740035 SRR1740043 SRR1740058 SRR1740067
colData names(5): Cell.type time condition days dead
>
```