### PR TITLE
fixed wrong output on PCA variance proportion of reduce_dimensions.R

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,4 @@ renv/settings.json
 tidybulk.Rcheck/*
 ..Rcheck/*
 vignettes/cache/*
+tidybulk_check.Rproj

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Type: Package
 Package: tidybulk
 Title: Brings transcriptomics to the tidyverse 
-Version: 2.1.3
+Version: 2.1.4
 Authors@R: c(person("Stefano", "Mangiola", email = "mangiolastefano@gmail.com",
                   role = c("aut", "cre")),
             person("Maria", "Doyle", email = "Maria.Doyle@petermac.org",

--- a/R/reduce_dimensions.R
+++ b/R/reduce_dimensions.R
@@ -476,6 +476,8 @@ we suggest to partition the dataset for sample clusters.
       # Calculate principal components
       prcomp(scale = scale, ...)
     
+    var_explained = prcomp_obj$sdev^2 / sum(prcomp_obj$sdev^2)
+    var_explained = var_explained[components]
     # Return
     list(
       raw_result = prcomp_obj,
@@ -486,9 +488,7 @@ we suggest to partition the dataset for sample clusters.
         # output: PCA object
         (\(.) {
           message("Fraction of variance explained by the selected principal components")
-          (.) %$% sdev |> pow(2) |> # Eigen value
-            unlist() |> divide_by(sum(unlist(prcomp_obj$sdev^2))) |>
-            _[components] |>
+          var_explained |> 
             enframe() |>
             select(-name) |>
             rename(`Fraction of variance` = value) |>

--- a/R/reduce_dimensions.R
+++ b/R/reduce_dimensions.R
@@ -487,7 +487,7 @@ we suggest to partition the dataset for sample clusters.
         (\(.) {
           message("Fraction of variance explained by the selected principal components")
           (.) %$% sdev |> pow(2) |> # Eigen value
-            unlist() |> divide_by(sum(unlist(.))) |>
+            unlist() |> divide_by(sum(unlist(prcomp_obj$sdev^2))) |>
             _[components] |>
             enframe() |>
             select(-name) |>

--- a/inst/NEWS.rd
+++ b/inst/NEWS.rd
@@ -108,3 +108,9 @@
     \item Remove deprecated warnings and redundant messages
     \item Several bug fixes and optimizations
 }}
+
+\section{Changes in version 2.1.4, Bioconductor 3.23 Release}{
+\itemize{
+    \item Fixed bug in the reported variance covered by PCA dimensionality reduction
+    \item improved legibility in reduce_dimension (PCA only)
+}}

--- a/tests/testthat/test-dimensionality-reduction.R
+++ b/tests/testthat/test-dimensionality-reduction.R
@@ -29,6 +29,15 @@ test_that("reduce_dimensions with PCA works correctly", {
   expect_true("PC2" %in% names(SummarizedExperiment::colData(res)))
 })
 
+test_that("reduce_dimensions with PCA reports correct variance", {
+  testthat::expect_message(airway_mini |> 
+                             identify_abundant() |> 
+                             reduce_dimensions(assay = "counts", method = "PCA"), 
+                           "0.698") #this is the pct of variance explained by the first PC 
+})
+
+
+
 test_that("reduce_dimensions with MDS works correctly", {
   res <- airway_mini |> identify_abundant() |> reduce_dimensions(assay = "counts", method = "MDS")
   


### PR DESCRIPTION
the `.`proportion here calls back to prcomp_obj, thus dividing by that instead of just the standard deviation, leading to a wrong result. 